### PR TITLE
Added the dirname arg substitution.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.svg
+*.png
+*.pdf
+*.pyc

--- a/examples/fake_package/launch/dirname.launch
+++ b/examples/fake_package/launch/dirname.launch
@@ -1,0 +1,6 @@
+<launch>
+    <!-- Handle the dirname directive. Should return the path bthat this launch file is in. -->
+    <!-- New in Lunar.-->
+    <include file="$(dirname)/triplet.launch" />
+    
+</launch>

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -24,6 +24,7 @@ from test_show_node_type import TestShowNodeType
 from test_disable_groups import TestDisableGroups
 from test_nodes_same_name import TestNodesSameName
 from test_missing_launch_file import TestMissingLaunchFile
+from test_dirname import TestDirname
 
 # Check for the ROS environment
 try:

--- a/tests/test_dirname.py
+++ b/tests/test_dirname.py
@@ -1,0 +1,21 @@
+import unittest
+from os import environ
+
+from util import roslaunch_to_dot, Color, ErrorMsg
+
+
+class TestDirname(unittest.TestCase):
+    EnvVar = "ROBOT"
+
+    def testDirname(self):
+        launchFile = "examples/fake_package/launch/dirname.launch"
+
+        status, output, graph = roslaunch_to_dot(launchFile)
+
+        # Should not have failed (the error gets caught and does not propagate
+        # to the top level)
+        self.assertEqual(status, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
New in Lunar is the $(dirname) substitution that resolves to the directory of the current launch file.
See http://wiki.ros.org/roslaunch/XML 

Modified the SubArgsPattern to accept "$(dirname)
Added a function to substitutionArgFnMap
Added an example and test

Made a few minor changes to the function docs and the arg not found exception.